### PR TITLE
Added flag to disable router event page tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markpieszak/ng-application-insights",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",


### PR DESCRIPTION
Added a flag to the config set, so that users of the package have the option to disable the built in Angular page tracking and create a custom implementation in their application.

#14