### PR TITLE
fix: stop page track on navigation cancel/error events

### DIFF
--- a/src/app-insight.service.ts
+++ b/src/app-insight.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Optional } from '@angular/core';
-import { Router, NavigationStart, NavigationEnd } from '@angular/router';
+import { Router, NavigationStart, NavigationEnd, NavigationCancel, NavigationError } from '@angular/router';
 import { AppInsights } from 'applicationinsights-js';
 import { filter } from 'rxjs/operators';
 
@@ -227,7 +227,11 @@ export class AppInsightsService implements IAppInsights {
               });
 
             this.router.events.pipe(
-              filter(event => event instanceof NavigationEnd)
+              filter(event => (
+                event instanceof NavigationEnd ||
+                event instanceof NavigationCancel ||
+                event instanceof NavigationError
+              ))
             )
               .subscribe((event: NavigationEnd) => {
                 this.stopTrackPage(event.url);


### PR DESCRIPTION
Handles NavigationCancel and NavigationError angular router events, stopping page tracking for a given URL if either event occurs.