### PR TITLE
Fix cyclic dependency when using APP_INITIALIZER

### DIFF
--- a/src/app-insight.service.ts
+++ b/src/app-insight.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@angular/core';
+import { Injectable, Optional, Injector } from '@angular/core';
 import { Router, NavigationStart, NavigationEnd, NavigationCancel, NavigationError } from '@angular/router';
 import { AppInsights } from 'applicationinsights-js';
 import { filter } from 'rxjs/operators';
@@ -47,7 +47,7 @@ export class AppInsightsService implements IAppInsights {
 
   constructor(
     @Optional() _config: AppInsightsConfig,
-    public router: Router
+    private _injector: Injector
   ) {
     this.config = _config;
   }
@@ -251,6 +251,10 @@ export class AppInsightsService implements IAppInsights {
     } else {
       console.warn('You need forRoot on ApplicationInsightsModule, with or instrumentationKeySetlater or instrumentationKey set at least');
     }
+  }
+
+  private get router() {
+    return this._injector.get(Router);
   }
 }
 


### PR DESCRIPTION
fixes #54 

When using the service in combination with `APP_INITIALIZER`, a cyclic dependency happens since `Router` is not yet resolved. `Router` won't be registered until the app is initialized, so the app is stuck waiting for both processes to complete. Resolving `Router` using the `Injector` fixes this problem.