### PR TITLE
Update to use proxy for AppInsigts context and queue

### DIFF
--- a/src/app-insight.service.ts
+++ b/src/app-insight.service.ts
@@ -46,8 +46,12 @@ export class AppInsightsConfig implements Microsoft.ApplicationInsights.IConfig 
 @Injectable()
 export class AppInsightsService implements IAppInsights {
 
-  context: Microsoft.ApplicationInsights.ITelemetryContext;
-  queue: Array<() => void>;
+  get context(): Microsoft.ApplicationInsights.ITelemetryContext {
+    return AppInsights.context;
+  }
+  get queue(): Array<() => void> {
+    return AppInsights.queue
+  }
   config: AppInsightsConfig;
 
   constructor(
@@ -242,9 +246,6 @@ export class AppInsightsService implements IAppInsights {
                 this.stopTrackPage(event.url);
               });
           }
-
-          this.queue = AppInsights.queue;
-          this.context = AppInsights.context;
         } catch (ex) {
           console.warn('Angular application insights Error [downloadAndSetup]: ', ex);
         }


### PR DESCRIPTION
AppInsights doesn't load immediately and as a result the library loads the 'undefined' reference and never gets updated.

This change simply uses a computer field to proxy to the current underlying instances always.